### PR TITLE
chore(GH actions): fix warning “Node.js 16 actions are deprecated”

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
cf eg the warning visible here: https://github.com/DevoInc/eslint-config-devo/actions/runs/8703995544